### PR TITLE
Add Glama MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Model Context Protocol (MCP) server that helps read GitHub repository structur
 
 Inspired by [gitingest](https://gitingest.com/).
 
+<a href="https://glama.ai/mcp/servers/un2zatig9e"><img width="380" height="200" src="https://glama.ai/mcp/servers/un2zatig9e/badge" /></a>
+
 ## Configuration
 
 ```json


### PR DESCRIPTION
This PR adds a badge for the `mcp-git-ingest` server linsting in Glama MCP server directory.

https://glama.ai/mcp/servers/un2zatig9e

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.